### PR TITLE
Add support for multiple tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Following is the full list of parameters required by this orb's various commands
 | `path` | `string` | `.` | path to Dockerfile, defaults to the working directory |
 | `registry-name` | `string` |  N/A | name of your ACR registry |
 | `repo` | `string` |  N/A | name of your ACR repository |
-| `tag` | `string` |  `latest` | ACR image tag |
+| `tag` | `string` |  `latest` | ACR image tag (comma-delimited string) |
 | `workspace-root` | `string` |  `.` | Workspace root path that is either an absolute path or a path relative to the working directory. |
 
 ## Usage

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,4 +6,4 @@ description: >
 
 orbs:
   azure-cli: circleci/azure-cli@1.1.0
-  docker: circleci/docker@0.5.8
+  docker: circleci/docker@0.5.18

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -72,7 +72,7 @@ parameters:
 
   tag:
     type: string
-    description: Docker tag (default = latest)
+    description: Comma-delimited string containing docker image tags (default = latest)
     default: "latest"
 
   checkout:

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -75,7 +75,7 @@ parameters:
 
   tag:
     type: string
-    description: Docker tag (default = latest)
+    description: Comma-delimited string containing docker image tags (default = latest)
     default: "latest"
 
   checkout:


### PR DESCRIPTION
### Checklist
- [X] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues
The orb commands for building and pushing images use a version of the docker orbs that does not support multiple image tags

### Description
- Update dependencies to latest version of docker orb
- Update documentation to reflect the fact that multiple tags are supported

See https://github.com/CircleCI-Public/docker-orb/issues/36 for the original PR against the docker orb.