### PR TITLE
Update pipeline to use latest version of orb-tools [semver:skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   azure-acr: circleci/azure-acr@dev:alpha
   # TODO: Replace with release version of docker orb once ready
-  docker: circleci/docker@dev:bc60adc
+  docker: circleci/docker@dev:799e252
   orb-tools: circleci/orb-tools@9.0
 
 # Pipeline parameters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 
 orbs:
   azure-acr: circleci/azure-acr@dev:alpha
+  # TODO: Replace with release version of docker orb once ready
+  docker: circleci/docker@dev:bc60adc
   orb-tools: circleci/orb-tools@9.0
 
 # Pipeline parameters
@@ -46,6 +48,10 @@ workflows:
           path: test
           repo: azure-acr-orb
           tag: $CIRCLE_TAG
+          pre-steps:
+            - docker/install-docker-credential-helper
+            - docker/configure-docker-credentials-store
+
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/azure-acr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,7 @@ version: 2.1
 
 orbs:
   azure-acr: circleci/azure-acr@dev:alpha
-  # TODO: Replace with release version of docker orb once ready
-  docker: circleci/docker@dev:799e252
+  docker: circleci/docker@0.6.0
   orb-tools: circleci/orb-tools@9.0
 
 # Pipeline parameters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,28 +2,22 @@ version: 2.1
 
 orbs:
   azure-acr: circleci/azure-acr@dev:alpha
-  orb-tools: circleci/orb-tools@8.27.3
+  orb-tools: circleci/orb-tools@9.0
 
-# yaml anchor filters
-integration-dev_filters: &integration-dev_filters
-  branches:
-    ignore: /.*/
-  tags:
-    only: /integration-.*/
-
-integration-master_filters: &integration-master_filters
-  branches:
-    ignore: /.*/
-  tags:
-    only: /master-.*/
-
-prod-deploy_requires: &prod-deploy_requires
-  [
-    build-and-push-master
-  ]
+# Pipeline parameters
+parameters:
+  # These pipeline parameters are required by the "trigger-integration-tests-workflow"
+  # job, by default.
+  run-integration-tests:
+    type: boolean
+    default: false
+  dev-orb-version:
+    type: string
+    default: "dev:alpha"
 
 workflows:
   lint_pack-validate_publish-dev:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - orb-tools/lint
 
@@ -35,90 +29,34 @@ workflows:
           context: orb-publishing
           requires: [orb-tools/pack]
 
-      - orb-tools/trigger-integration-workflow:
+      - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
           context: orb-publishing
-          ssh-fingerprints: 70:8f:c6:8c:5a:57:46:d7:39:b7:ff:4c:94:a4:7f:6a
           requires: [orb-tools/publish-dev]
-          filters:
-            branches:
-              ignore: master
 
-      - orb-tools/trigger-integration-workflow:
-          name: trigger-integration-master
+  integration-tests_prod-release:
+    when: << pipeline.parameters.run-integration-tests >>
+    jobs:
+      - azure-acr/build-and-push-image:
+          name: build-and-push
           context: orb-publishing
-          ssh-fingerprints: 70:8f:c6:8c:5a:57:46:d7:39:b7:ff:4c:94:a4:7f:6a
-          tag: master
-          cleanup-tags: true
-          requires: [orb-tools/publish-dev]
+          registry-name: azureorbs
+          login-server-name: azureorbs.azurecr.io
+          dockerfile: test.Dockerfile
+          path: test
+          repo: azure-acr-orb
+          tag: $CIRCLE_TAG
+
+      - orb-tools/dev-promote-prod-from-commit-subject:
+          orb-name: circleci/azure-acr
+          context: orb-publishing
+          add-pr-comment: true
+          bot-token-variable: GHI_TOKEN
+          bot-user: cpe-bot
+          fail-if-semver-not-indicated: true
+          publish-version-tag: false
+          requires:
+            - build-and-push
           filters:
             branches:
               only: master
-
-  integration-tests_prod-release:
-    jobs:
-      # triggered by non-master branch commits
-      - azure-acr/build-and-push-image:
-          name: build-and-push-dev
-          context: orb-publishing
-          registry-name: azureorbs
-          login-server-name: azureorbs.azurecr.io
-          dockerfile: test.Dockerfile
-          path: test
-          repo: azure-acr-orb
-          tag: $CIRCLE_TAG
-          filters: *integration-dev_filters
-
-      # triggered by master branch commits
-      - azure-acr/build-and-push-image:
-          name: build-and-push-master
-          context: orb-publishing
-          registry-name: azureorbs
-          login-server-name: azureorbs.azurecr.io
-          dockerfile: test.Dockerfile
-          path: test
-          repo: azure-acr-orb
-          tag: $CIRCLE_TAG
-          filters: *integration-master_filters
-
-      # patch, minor, or major publishing
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-patch
-          context: orb-publishing
-          orb-name: circleci/azure-acr
-          ssh-fingerprints: 70:8f:c6:8c:5a:57:46:d7:39:b7:ff:4c:94:a4:7f:6a
-          cleanup-tags: true
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-patch.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-minor
-          context: orb-publishing
-          orb-name: circleci/azure-acr
-          ssh-fingerprints: 70:8f:c6:8c:5a:57:46:d7:39:b7:ff:4c:94:a4:7f:6a
-          cleanup-tags: true
-          release: minor
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-minor.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-major
-          context: orb-publishing
-          orb-name: circleci/azure-acr
-          ssh-fingerprints: 70:8f:c6:8c:5a:57:46:d7:39:b7:ff:4c:94:a4:7f:6a
-          cleanup-tags: true
-          release: major
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-major.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ workflows:
       - azure-acr/build-and-push-image:
           name: build-and-push
           context: orb-publishing
-          registry-name: azureorbs
-          login-server-name: azureorbs.azurecr.io
+          registry-name: azureacrorb
+          login-server-name: azureacrorb.azurecr.io
           dockerfile: test.Dockerfile
           path: test
           repo: azure-acr-orb


### PR DESCRIPTION
This updates the CircleCI config to use the same pipeline as in orb-starter-kit. There is no change to the orb itself.

Note:
- To avoid the integration test failing due to https://github.com/CircleCI-Public/azure-acr-orb/issues/11, we also update the pipeline to make use of the new `install-docker-credential-helper` and `configure-docker-credentials-store` commands in the `circleci/docker` orb.
- The Azure container registry (`azureorbs`) previously used in the integration test is not available for use, hence the integration test uses a differently-named one now (`azureacrorb`).