### PR TITLE
Configure docker credentials store [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   azure-acr: circleci/azure-acr@dev:alpha
-  docker: circleci/docker@0.6.0
+  docker: circleci/docker@0.6
   orb-tools: circleci/orb-tools@9.0
 
 # Pipeline parameters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   azure-acr: circleci/azure-acr@dev:alpha
   # TODO: Replace with release version of docker orb once ready
-  docker: circleci/docker@dev:799e252
+  docker: circleci/docker@dev:7545885
   orb-tools: circleci/orb-tools@9.0
 
 # Pipeline parameters
@@ -48,10 +48,6 @@ workflows:
           path: test
           repo: azure-acr-orb
           tag: $CIRCLE_TAG
-          pre-steps:
-            - docker/install-docker-credential-helper
-            - docker/configure-docker-credentials-store
-
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/azure-acr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   azure-acr: circleci/azure-acr@dev:alpha
-  docker: circleci/docker@0.6
   orb-tools: circleci/orb-tools@9.0
 
 # Pipeline parameters

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,8 +2,11 @@ version: 2.1
 
 description: >
   Build images and push them to Azure Container Registry.
-  See this orb's source: https://github.com/CircleCI-Public/azure-acr-orb
+
+display:
+  source_url: https://github.com/CircleCI-Public/azure-acr-orb
 
 orbs:
   azure-cli: circleci/azure-cli@1.1.0
-  docker: circleci/docker@0.5.18
+  # TODO: Replace with release version of docker orb once ready
+  docker: circleci/docker@dev:7545885

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,5 +8,4 @@ display:
 
 orbs:
   azure-cli: circleci/azure-cli@1.1.0
-  # TODO: Replace with release version of docker orb once ready
-  docker: circleci/docker@dev:7545885
+  docker: circleci/docker@0.6

--- a/src/commands/acr-login.yml
+++ b/src/commands/acr-login.yml
@@ -12,14 +12,13 @@ parameters:
     default: true
     description: >
       Configure Docker to use a credentials store.
-      This option is only supported on Ubuntu/Debian platforms.
+      Supported platforms: Linux/macOS.
 
 steps:
   - when:
       condition: <<parameters.configure-docker-credentials-store>>
       steps:
-        - docker/install-docker-credential-helper
-        - docker/configure-docker-credentials-store
+        - configure-docker-credentials-store
   - run:
       name: Log into ACR
       command: |

--- a/src/commands/acr-login.yml
+++ b/src/commands/acr-login.yml
@@ -7,8 +7,19 @@ parameters:
       Name of env var storing your registry name,
       defaults to REGISTRY_NAME
     default: REGISTRY_NAME
+  configure-docker-credentials-store:
+    type: boolean
+    default: true
+    description: >
+      Configure Docker to use a credentials store.
+      This option is only supported on Ubuntu/Debian platforms.
 
 steps:
+  - when:
+      condition: <<parameters.configure-docker-credentials-store>>
+      steps:
+        - docker/install-docker-credential-helper
+        - docker/configure-docker-credentials-store
   - run:
       name: Log into ACR
       command: |

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -71,7 +71,7 @@ parameters:
     default: true
     description: >
       Configure Docker to use a credentials store.
-      This option is only supported on Ubuntu/Debian platforms.
+      Supported platforms: Linux/macOS.
 
   repo:
     type: string

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -66,6 +66,13 @@ parameters:
       The Azure login server for your ACR instance,
       e.g. {yourregistryname}.azure.io
 
+  configure-docker-credentials-store:
+    type: boolean
+    default: true
+    description: >
+      Configure Docker to use a credentials store.
+      This option is only supported on Ubuntu/Debian platforms.
+
   repo:
     type: string
     description: Name of an ACR repository
@@ -152,6 +159,7 @@ steps:
 
   - acr-login:
       registry-name: <<parameters.registry-name>>
+      configure-docker-credentials-store: <<parameters.configure-docker-credentials-store>>
 
   - docker/build:
       step-name: Build Docker image for ACR

--- a/src/commands/configure-docker-credentials-store.yml
+++ b/src/commands/configure-docker-credentials-store.yml
@@ -1,0 +1,12 @@
+description: >
+  Install the ACR docker credential helper and configure Docker to use
+  it for its credentials store.
+  Requires bash and Docker to be available.
+
+steps:
+  - run:
+      name: Configure Azure ACR helper
+      command: |
+          # Run ACR Docker Credential Helper installation script
+          # https://github.com/Azure/acr-docker-credential-helper#installation
+          curl -L https://aka.ms/acr/installaad/bash | /bin/bash

--- a/src/examples/build-and-push-image.yml
+++ b/src/examples/build-and-push-image.yml
@@ -1,0 +1,17 @@
+description: >
+  Build and push a Docker image to the Azure Container Registry (ACR)
+
+usage:
+  version: 2.1
+
+  orbs:
+    azure-acr: circleci/azure-acr@x.y.z
+
+  workflows:
+    build-and-publish-docker-image:
+      jobs:
+        - azure-acr/build-and-push-image:
+            registry-name: exampleregistry
+            login-server-name: exampleregistry.azurecr.io
+            repo: example-repository
+            tag: $CIRCLE_TAG

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -69,6 +69,13 @@ parameters:
       The Azure login server for your ACR instance,
       e.g. {yourregistryname}.azure.io
 
+  configure-docker-credentials-store:
+    type: boolean
+    default: true
+    description: >
+      Configure Docker to use a credentials store.
+      This option is only supported on Ubuntu/Debian platforms.
+
   repo:
     type: string
     description: A URI to an ACR login-server-name/repository
@@ -128,6 +135,7 @@ steps:
       azure-tenant: <<parameters.azure-tenant>>
       registry-name: <<parameters.registry-name>>
       login-server-name: <<parameters.login-server-name>>
+      configure-docker-credentials-store: <<parameters.configure-docker-credentials-store>>
       repo: <<parameters.repo>>
       tag: <<parameters.tag>>
       dockerfile: <<parameters.dockerfile>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -74,7 +74,7 @@ parameters:
     default: true
     description: >
       Configure Docker to use a credentials store.
-      This option is only supported on Ubuntu/Debian platforms.
+      Supported platforms: Linux/macOS.
 
   repo:
     type: string


### PR DESCRIPTION
Resolves https://github.com/CircleCI-Public/azure-acr-orb/issues/11 by configuring a credentials store to be used for login by default.